### PR TITLE
Update details of Xen support

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -572,11 +572,19 @@
         },
         {
             "project_id": "openstack/nova",
-            "vendor": "Citrix",
-            "name": "Xen",
-            "description": "No description provided",
+            "vendor": "OpenStack Community",
+            "name": "Xen+Libvirt",
+            "description": "Support for the Xen hypervisor when used with libvirt",
+            "wiki": "http://docs.openstack.org/trunk/config-reference/content/introduction-to-xen.html"
+        },
+        {
+            "project_id": "openstack/nova",
+            "vendor": "OpenStack Community",
+            "name": "XenAPI",
+            "description": "XenAPI compute driver connects to XenServer hypervisors via XenAPI. Used to power Rackspace Cloud Servers (Public Cloud).",
             "wiki": "http://docs.openstack.org/trunk/config-reference/content/introduction-to-xen.html",
-            "ci_id": "citrix_xenserver_ci"
+            "ci_id": "citrix_xenserver_ci",
+            "releases": ["Austin", "Bexar", "Cactus", "Diablo", "Essex", "Folsom", "Grizzly", "Havana", "Icehouse"]
         },
         {
             "project_id": "openstack/nova",


### PR DESCRIPTION
There are two nova drivers:
- XenAPI driver for XenServer
- Libvirt + Xen

Currently only the XenAPI is a support Nova driver. The initial
prototype was available in the Austin release, but started really
working in the Bexar release.

The XenServer ci is testing the XenAPI driver, not the Xen+libvirt
driver.

None of these are whole Citrix contributions, the XenAPI is mostly
maintained by Rackspace, but also a few others. The libvirt based driver
for Xen has never had any support from Citrix, and has recently had the
most support from SUSE.
